### PR TITLE
ignoring pydantic-core in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,5 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "pydantic-core"


### PR DESCRIPTION
it always makes it error out with a pypi tls error