### PR TITLE
[META] Remove pydantic ignore from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,5 +11,3 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 5
-    ignore:
-      - dependency-name: "pydantic-core"


### PR DESCRIPTION
due to an [upstream bug](https://github.com/github/dependabot-action/pull/1475) in dependabot being fixed 16h ago it is now compatible with python 3.13 dependencies. this means we can now remove the ignore statement for pydantic previously  put in place because it was breaking dependabot.